### PR TITLE
update map message 

### DIFF
--- a/src/app/block/Map/index.tsx
+++ b/src/app/block/Map/index.tsx
@@ -86,7 +86,8 @@ const Map: React.FC<MapProps> = ({ data }) => {
                 return (
                     <div className={styles.popup}>
                         <Image width={20} height={26} src={'/lightOpen.svg'} alt={'light-open'} />
-                        <span>Your node is connected and visible on the network！</span>
+                        <span>&nbsp;<br />Your node is connectable and visible on the network！<br /> Map location is approximated based on IP address :) <br /> &nbsp;
+                        </span>
                         <Image width={18} height={18} src={'/close.svg'} alt={'light-open'} onClick={() => setErrorType(-1)}/>
                     </div>
                 );


### PR DESCRIPTION
update message for node being visible
to notice users that their node's location on the map is an approximate based on their IP address, not exact actual location. Especially if on a VPN, the node will show up on the map where your VPN output is, not their actual location.

